### PR TITLE
Header diff

### DIFF
--- a/Dokan.pas
+++ b/Dokan.pas
@@ -439,8 +439,8 @@ procedure DokanFree();
 
 procedure DokanInit; stdcall;
 procedure DokanShutdown; stdcall;
-function DokanMain(Options: DOKAN_OPTIONS; Operations: DOKAN_OPERATIONS): Integer; stdcall;
-function DokanCreateFileSystem(DokanOptions : DOKAN_OPTIONS; DokanOperations : DOKAN_OPERATIONS; var DokanInstance : DOKAN_HANDLE) : Integer; stdcall;
+function DokanMain(var Options: DOKAN_OPTIONS; var Operations: DOKAN_OPERATIONS): Integer; stdcall;
+function DokanCreateFileSystem(var DokanOptions : DOKAN_OPTIONS; var DokanOperations : DOKAN_OPERATIONS; var DokanInstance : DOKAN_HANDLE) : Integer; stdcall;
 function DokanIsFileSystemRunning(DokanInstance : DOKAN_HANDLE) : BOOL; stdcall;
 function DokanWaitForFileSystemClosed(DokanInstance : DOKAN_HANDLE; dwMilliseconds : DWORD) : DWORD; stdcall;
 procedure DokanCloseHandle(DokanInstance : DOKAN_HANDLE); stdcall;

--- a/Dokan.pas
+++ b/Dokan.pas
@@ -44,7 +44,7 @@ const
   DokanLibrary = 'dokan2.dll';
 
   //The current Dokan version (200 means ver 2.0.0).
-  DOKAN_VERSION = 200;
+  DOKAN_VERSION = 206;
   //Minimum Dokan version (ver 2.0.0) accepted
   DOKAN_MINIMUM_COMPATIBLE_VERSION = 200;
 


### PR DESCRIPTION
DokanMain and DokanCreateFileSystem need DOKAN_OPTIONS and DOKAN_OPERATIONS to be passed as pointers. 